### PR TITLE
Replace text with string

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ To use it, you need to have an array column to act as taggable.
 class CreateUser < ActiveRecord::Migration
   def change
     create_table :users do |t|
-      t.text :tags, array: true, default: '{}'
+      t.string :tags, array: true, default: '{}'
       t.timestamps
     end
     add_index :users, :tags, using: 'gin'

--- a/lib/acts-as-taggable-array-on/taggable.rb
+++ b/lib/acts-as-taggable-array-on/taggable.rb
@@ -8,10 +8,10 @@ module ActsAsTaggableArrayOn
       def acts_as_taggable_array_on(*tag_def)
         tag_name = tag_def.first
 
-        scope :"with_any_#{tag_name}", ->(* tags){where("#{tag_name} && ARRAY[?]", tags)}
-        scope :"with_all_#{tag_name}", ->(* tags){where("#{tag_name} @> ARRAY[?]", tags)}
-        scope :"without_any_#{tag_name}", ->(* tags){where.not("#{tag_name} && ARRAY[?]", tags)}
-        scope :"without_all_#{tag_name}", ->(* tags){where.not("#{tag_name} @> ARRAY[?]", tags)}
+        scope :"with_any_#{tag_name}", ->(* tags){where("#{tag_name} && ARRAY[?]::varchar[]", tags)}
+        scope :"with_all_#{tag_name}", ->(* tags){where("#{tag_name} @> ARRAY[?]::varchar[]", tags)}
+        scope :"without_any_#{tag_name}", ->(* tags){where.not("#{tag_name} && ARRAY[?]::varchar[]", tags)}
+        scope :"without_all_#{tag_name}", ->(* tags){where.not("#{tag_name} @> ARRAY[?]::varchar[]", tags)}
 
         self.class.class_eval do
           define_method :"all_#{tag_name}" do |options = {}, &block|

--- a/spec/acts_as_tag_pgarray/taggable_spec.rb
+++ b/spec/acts_as_tag_pgarray/taggable_spec.rb
@@ -37,13 +37,13 @@ describe ActsAsTaggableArrayOn::Taggable do
   end
   
   describe "#without_any_tags" do
-    it "returns users having any tags of args" do
+    it "returns users not having any tags of args" do
       expect(User.without_any_colors('red', 'blue')).to match_array([])
     end
   end
 
   describe "#without_all_tags" do
-    it "returns users having all tags of args" do
+    it "returns users not having all tags of args" do
       expect(User.without_all_colors('red', 'blue')).to match_array([@user2,@user3])
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -37,7 +37,7 @@ def create_database
   ActiveRecord::Schema.define(:version => 1) do
     create_table :users do |t|
       t.string :name
-      t.text :colors, array: true, defualt: '{}'
+      t.string :colors, array: true, defualt: '{}'
       t.timestamps
     end
   end


### PR DESCRIPTION
User can create tags of arbitrary length with `Text` element. This exposes the application using this gem to the denial of service attacks. Using `String` limits individual tags within 255 bytes.
