### PR TITLE
Work with joined tables, define columns unambiguously

### DIFF
--- a/lib/acts-as-taggable-array-on/taggable.rb
+++ b/lib/acts-as-taggable-array-on/taggable.rb
@@ -14,10 +14,10 @@ module ActsAsTaggableArrayOn
         tag_array_type = TYPE_MATCHER[columns_hash[tag_name.to_s].type]
         parser = ActsAsTaggableArrayOn.parser
 
-        scope :"with_any_#{tag_name}", ->(tags){ where("#{tag_name} && ARRAY[?]::#{tag_array_type}[]", parser.parse(tags)) }
-        scope :"with_all_#{tag_name}", ->(tags){ where("#{tag_name} @> ARRAY[?]::#{tag_array_type}[]", parser.parse(tags)) }
-        scope :"without_any_#{tag_name}", ->(tags){ where.not("#{tag_name} && ARRAY[?]::#{tag_array_type}[]", parser.parse(tags)) }
-        scope :"without_all_#{tag_name}", ->(tags){ where.not("#{tag_name} @> ARRAY[?]::#{tag_array_type}[]", parser.parse(tags)) }
+        scope :"with_any_#{tag_name}", ->(tags){ where("#{table_name}.#{tag_name} && ARRAY[?]::#{tag_array_type}[]", parser.parse(tags)) }
+        scope :"with_all_#{tag_name}", ->(tags){ where("#{table_name}.#{tag_name} @> ARRAY[?]::#{tag_array_type}[]", parser.parse(tags)) }
+        scope :"without_any_#{tag_name}", ->(tags){ where.not("#{table_name}.#{tag_name} && ARRAY[?]::#{tag_array_type}[]", parser.parse(tags)) }
+        scope :"without_all_#{tag_name}", ->(tags){ where.not("#{table_name}.#{tag_name} @> ARRAY[?]::#{tag_array_type}[]", parser.parse(tags)) }
 
         self.class.class_eval do
           define_method :"all_#{tag_name}" do |options = {}, &block|

--- a/spec/acts_as_tag_pgarray/taggable_spec.rb
+++ b/spec/acts_as_tag_pgarray/taggable_spec.rb
@@ -26,6 +26,20 @@ describe ActsAsTaggableArrayOn::Taggable do
     end
   end
 
+  it 'should define table name un-ambiguously' do
+    sql = User.with_any_sizes(['small']).to_sql
+    expect(sql).to eql("SELECT \"users\".* FROM \"users\" WHERE (users.sizes && ARRAY['small']::text[])")
+
+    sql = User.with_all_sizes(['small']).to_sql
+    expect(sql).to eql("SELECT \"users\".* FROM \"users\" WHERE (users.sizes @> ARRAY['small']::text[])")
+
+    sql = User.without_any_sizes(['small']).to_sql
+    expect(sql).to eql("SELECT \"users\".* FROM \"users\" WHERE (NOT (users.sizes && ARRAY['small']::text[]))")
+
+    sql = User.without_all_sizes(['small']).to_sql
+    expect(sql).to eql("SELECT \"users\".* FROM \"users\" WHERE (NOT (users.sizes @> ARRAY['small']::text[]))")
+  end
+
   it "should work with ::text typed array" do
     expect(User.with_any_sizes(['small'])).to match_array([@user2,@user3])
     expect(User.with_all_sizes(['small', 'large'])).to match_array([@user2,@user3])


### PR DESCRIPTION
I've joined couple of tables together and tried to use my tags column in a scope.

```
class Product < ApplicationRecord
  scope :with_all_categories, ->(category) { Product.joins(:store_products).merge(StoreProduct.with_all_categories(category))}
end
```

And ended up with an error, that proposes that column is ambiguously defined:
```
ActiveRecord::StatementInvalid:         ActiveRecord::StatementInvalid: PG::AmbiguousColumn: ERROR:  column reference "categories" is ambiguous
        LINE 1: ..." = $1 AND "products"."discarded_at" IS NULL AND (categories...
```

 This patch fixed it for me.