### PR TITLE
silence Rails 6 dangerous query method deprecation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ addons:
 gemfile:
   - gemfiles/rails_4.gemfile
   - gemfiles/rails_5.gemfile
+  - gemfiles/rails_6.gemfile
 before_script:
   - bundle exec rake db:create
 script:

--- a/gemfiles/rails_6.gemfile
+++ b/gemfiles/rails_6.gemfile
@@ -1,0 +1,9 @@
+source 'https://rubygems.org'
+
+# Specify your gem's dependencies in acts-as-pgarray-taggable-on.gemspec
+gemspec path: '../'
+
+git "https://github.com/rails/rails.git" do
+ gem 'activerecord'
+ gem 'activesupport'
+end

--- a/lib/acts-as-taggable-array-on/taggable.rb
+++ b/lib/acts-as-taggable-array-on/taggable.rb
@@ -31,7 +31,7 @@ module ActsAsTaggableArrayOn
             subquery_scope = unscoped.select("unnest(#{table_name}.#{tag_name}) as tag")
             subquery_scope = subquery_scope.instance_eval(&block) if block
 
-            from(subquery_scope).group('tag').order('tag').pluck('tag, count(*) as count')
+            from(subquery_scope).group('tag').order('tag').pluck(Arel.sql('tag, count(*) as count'))
           end
         end
       end


### PR DESCRIPTION
To silence rails 6 errors, I added `Arel.sql()` to pluck method, even though the deprecation didn't make sense.

```
DEPRECATION WARNING: Dangerous query method (method whose arguments are used as raw SQL) called with non-attribute argument(s): "tag, count(*) as count". Non-attribute arguments will be disallowed in Rails 6.0. This method should not be called with user-provided values, such as request parameters or model attributes. Known-safe values can be passed by wrapping them in Arel.sql(). (called from block (2 levels) in acts_as_taggable_array_on at /Users/chong/Workspace/opensauce/acts-as-taggable-array-on/lib/acts-as-taggable-array-on/taggable.rb:34)
```