### PR TITLE
Update travis.yml to test modern versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,20 @@
 language: ruby
 rvm:
   - 2.1.10
-  - 2.2.9
-  - 2.3.6
-  - 2.4.3
-  - 2.4.3
-  - 2.5.0
-addons:
-  postgresql: 9.3
+  - 2.2.10
+  - 2.3.8
+  - 2.4.7
+  - 2.5.6
+  - 2.6.4
+services:
+  - postgresql
 gemfile:
   - gemfiles/rails_4.gemfile
   - gemfiles/rails_5.gemfile
+  - gemfiles/rails_5_2.gemfile
+  - gemfiles/rails_6_0.gemfile
 before_script:
+  - cp config/database.yml.travis config/database.yml
   - bundle exec rake db:create
 script:
   - bundle
@@ -20,3 +23,15 @@ matrix:
   exclude:
     - rvm: 2.1.10
       gemfile: gemfiles/rails_5.gemfile
+    - rvm: 2.1.10
+      gemfile: gemfiles/rails_5_2.gemfile
+    - rvm: 2.1.10
+      gemfile: gemfiles/rails_6_0.gemfile
+    - rvm: 2.2.10
+      gemfile: gemfiles/rails_5_2.gemfile
+    - rvm: 2.2.10
+      gemfile: gemfiles/rails_6_0.gemfile
+    - rvm: 2.3.8
+      gemfile: gemfiles/rails_6_0.gemfile
+    - rvm: 2.4.7
+      gemfile: gemfiles/rails_6_0.gemfile

--- a/config/database.yml.travis
+++ b/config/database.yml.travis
@@ -1,0 +1,3 @@
+test:
+  adapter: postgresql
+  database: travis_ci_test

--- a/gemfiles/rails_5_2.gemfile
+++ b/gemfiles/rails_5_2.gemfile
@@ -1,0 +1,7 @@
+source 'https://rubygems.org'
+
+# Specify your gem's dependencies in acts-as-pgarray-taggable-on.gemspec
+gemspec path: '../'
+
+gem 'activerecord',  '~> 5.2.0'
+gem 'activesupport', '~> 5.2.0'

--- a/gemfiles/rails_6_0.gemfile
+++ b/gemfiles/rails_6_0.gemfile
@@ -1,0 +1,7 @@
+source 'https://rubygems.org'
+
+# Specify your gem's dependencies in acts-as-pgarray-taggable-on.gemspec
+gemspec path: '../'
+
+gem 'activerecord',  '~> 6.0.0'
+gem 'activesupport', '~> 6.0.0'

--- a/spec/acts_as_tag_pgarray/taggable_spec.rb
+++ b/spec/acts_as_tag_pgarray/taggable_spec.rb
@@ -42,10 +42,18 @@ describe ActsAsTaggableArrayOn::Taggable do
     expect(sql).to eql("SELECT \"users\".* FROM \"users\" WHERE (users.sizes @> ARRAY['small']::text[])")
 
     sql = User.without_any_sizes(['small']).to_sql
-    expect(sql).to eql("SELECT \"users\".* FROM \"users\" WHERE (NOT (users.sizes && ARRAY['small']::text[]))")
+    if ActiveRecord.version.to_s < "5.2.0"
+      expect(sql).to eql("SELECT \"users\".* FROM \"users\" WHERE (NOT (users.sizes && ARRAY['small']::text[]))")
+    else
+      expect(sql).to eql("SELECT \"users\".* FROM \"users\" WHERE NOT (users.sizes && ARRAY['small']::text[])")
+    end
 
     sql = User.without_all_sizes(['small']).to_sql
-    expect(sql).to eql("SELECT \"users\".* FROM \"users\" WHERE (NOT (users.sizes @> ARRAY['small']::text[]))")
+    if ActiveRecord.version.to_s < "5.2.0"
+      expect(sql).to eql("SELECT \"users\".* FROM \"users\" WHERE (NOT (users.sizes @> ARRAY['small']::text[]))")
+    else
+      expect(sql).to eql("SELECT \"users\".* FROM \"users\" WHERE NOT (users.sizes @> ARRAY['small']::text[])")
+    end
   end
 
   it "should work with ::text typed array" do


### PR DESCRIPTION
Bumps point versions for old `ruby` versions, adds ruby `2.6`,
and adds gemfiles for rails `5.2` and `6.0`