### PR TITLE
Alias acts_as_taggable_array_on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## HEAD
+- Alias `acts_as_taggable_on` to `taggable_array`
+
 ## 0.5.1
 - Don't fail during load time if DB is missing
 

--- a/lib/acts-as-taggable-array-on/taggable.rb
+++ b/lib/acts-as-taggable-array-on/taggable.rb
@@ -34,6 +34,7 @@ module ActsAsTaggableArrayOn
           end
         end
       end
+      alias taggable_array acts_as_taggable_array_on
     end
   end
 end

--- a/spec/acts_as_tag_pgarray/taggable_spec.rb
+++ b/spec/acts_as_tag_pgarray/taggable_spec.rb
@@ -8,7 +8,7 @@ describe ActsAsTaggableArrayOn::Taggable do
 
     User.acts_as_taggable_array_on :colors
     User.acts_as_taggable_array_on :sizes
-    User.acts_as_taggable_array_on :codes
+    User.taggable_array :codes
   end
 
 
@@ -31,6 +31,21 @@ describe ActsAsTaggableArrayOn::Taggable do
     end
     it "defines named scope not to match all tags" do
       expect(User).to respond_to(:without_all_colors)
+    end
+  end
+
+  describe "#taggable_array_on" do
+    it "defines named scope to match any tags" do
+      expect(User).to respond_to(:with_any_codes)
+    end
+    it "defines named scope to match all tags" do
+      expect(User).to respond_to(:with_all_codes)
+    end
+    it "defines named scope not to match any tags" do
+      expect(User).to respond_to(:without_any_codes)
+    end
+    it "defines named scope not to match all tags" do
+      expect(User).to respond_to(:without_all_codes)
     end
   end
 


### PR DESCRIPTION
This PR adds a new `taggable_array` alias for `acts_as_taggable_array`
to provide a shorter, more distinct method.

The existing method names similarity with `acts_as_taggable` can cause
some confusion when migrating, as the name implies it works in a similar
way.

Added specs to cover the new functionality