### PR TITLE
Drop explicit legacy support for EOL ruby and gem versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,11 @@
 language: ruby
 rvm:
-  - 2.1.10
-  - 2.2.10
-  - 2.3.8
-  - 2.4.7
-  - 2.5.6
-  - 2.6.4
+  - 2.4.8
+  - 2.5.7
+  - 2.6.5
 services:
   - postgresql
 gemfile:
-  - gemfiles/rails_4.gemfile
-  - gemfiles/rails_5.gemfile
   - gemfiles/rails_5_2.gemfile
   - gemfiles/rails_6_0.gemfile
 before_script:
@@ -21,17 +16,5 @@ script:
   - bundle exec rspec
 matrix:
   exclude:
-    - rvm: 2.1.10
-      gemfile: gemfiles/rails_5.gemfile
-    - rvm: 2.1.10
-      gemfile: gemfiles/rails_5_2.gemfile
-    - rvm: 2.1.10
-      gemfile: gemfiles/rails_6_0.gemfile
-    - rvm: 2.2.10
-      gemfile: gemfiles/rails_5_2.gemfile
-    - rvm: 2.2.10
-      gemfile: gemfiles/rails_6_0.gemfile
-    - rvm: 2.3.8
-      gemfile: gemfiles/rails_6_0.gemfile
-    - rvm: 2.4.7
+    - rvm: 2.4.8
       gemfile: gemfiles/rails_6_0.gemfile

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## HEAD
+- Drop support for `EOL` versions of Ruby (below `2.4)`, and Rails (below `5.2`)
 - Alias `acts_as_taggable_on` to `taggable_array`
 
 ## 0.5.1

--- a/acts-as-taggable-array-on.gemspec
+++ b/acts-as-taggable-array-on.gemspec
@@ -18,14 +18,14 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency 'activerecord',  ['>= 4']
-  spec.add_runtime_dependency 'activesupport', ['>= 4']
+  spec.add_runtime_dependency 'activerecord',  ['>= 5.2']
+  spec.add_runtime_dependency 'activesupport', ['>= 5.2']
 
-  spec.add_development_dependency 'pg', '~> 0.18'
+  spec.add_development_dependency 'pg', '~> 1.1'
 
-  spec.add_development_dependency "bundler", "~> 1.5"
+  spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec-rails"
   spec.add_development_dependency "guard-rspec"
-  spec.add_development_dependency "listen",  "~> 3.0.0"
+  spec.add_development_dependency "listen", "> 3.0"
 end

--- a/gemfiles/rails_4.gemfile
+++ b/gemfiles/rails_4.gemfile
@@ -1,7 +1,0 @@
-source 'https://rubygems.org'
-
-# Specify your gem's dependencies in acts-as-pgarray-taggable-on.gemspec
-gemspec path: '../'
-
-gem 'activerecord',  '>= 4', '< 5'
-gem 'activesupport', '>= 4', '< 5'

--- a/gemfiles/rails_5.gemfile
+++ b/gemfiles/rails_5.gemfile
@@ -1,7 +1,0 @@
-source 'https://rubygems.org'
-
-# Specify your gem's dependencies in acts-as-pgarray-taggable-on.gemspec
-gemspec path: '../'
-
-gem 'activerecord',  '~> 5.0.0'
-gem 'activesupport', '~> 5.0.0'

--- a/spec/acts_as_tag_pgarray/taggable_spec.rb
+++ b/spec/acts_as_tag_pgarray/taggable_spec.rb
@@ -57,18 +57,10 @@ describe ActsAsTaggableArrayOn::Taggable do
     expect(sql).to eql("SELECT \"users\".* FROM \"users\" WHERE (users.sizes @> ARRAY['small']::text[])")
 
     sql = User.without_any_sizes(['small']).to_sql
-    if ActiveRecord.version.to_s < "5.2.0"
-      expect(sql).to eql("SELECT \"users\".* FROM \"users\" WHERE (NOT (users.sizes && ARRAY['small']::text[]))")
-    else
-      expect(sql).to eql("SELECT \"users\".* FROM \"users\" WHERE NOT (users.sizes && ARRAY['small']::text[])")
-    end
+    expect(sql).to eql("SELECT \"users\".* FROM \"users\" WHERE NOT (users.sizes && ARRAY['small']::text[])")
 
     sql = User.without_all_sizes(['small']).to_sql
-    if ActiveRecord.version.to_s < "5.2.0"
-      expect(sql).to eql("SELECT \"users\".* FROM \"users\" WHERE (NOT (users.sizes @> ARRAY['small']::text[]))")
-    else
-      expect(sql).to eql("SELECT \"users\".* FROM \"users\" WHERE NOT (users.sizes @> ARRAY['small']::text[])")
-    end
+    expect(sql).to eql("SELECT \"users\".* FROM \"users\" WHERE NOT (users.sizes @> ARRAY['small']::text[])")
   end
 
   it "should work with ::text typed array" do


### PR DESCRIPTION
Remove config to test against unsupported versions of ruby and rails.

This will reduce the time in spec runs, and allow use of modern features
when adding features going forward.

- [x] Update gemspec to require `pg > 1.0`
- [x] Update gemspec to require `active_record > 5.2`
- [x] Update gemspec to require `active_support > 5.2`
- [x] Update to current ruby versions in `travis.yml`
- [x] drop EOL ruby versions in `travis.yml`
- [x] drop EOL rails versions in `travis.yml`
- [x] remove legacy 'gemfiles'
- [x] remove remove shims for EOL `active_record` SQL in specs