### PR TITLE
Prepare for 0.6 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
-## HEAD
+## 0.6
 - Drop support for `EOL` versions of Ruby (below `2.4)`, and Rails (below `5.2`)
 - Alias `acts_as_taggable_on` to `taggable_array`
+- Stop rails 6 deprecation warnings
 
 ## 0.5.1
 - Don't fail during load time if DB is missing

--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # ActsAsTaggableArrayOn
 [![Build Status](https://travis-ci.org/tmiyamon/acts-as-taggable-array-on.svg?branch=master)](https://travis-ci.org/tmiyamon/acts-as-taggable-array-on)
 
-A simple implementation for tagging system with postgres array.
-So, this gem works only on postgres.
+A simple implementation for tagging system with postgres array. Please note, only PostgreSql database is supported.
 
 
 ## Installation
@@ -46,7 +45,7 @@ then
 
 ```ruby
 class User < ActiveRecord::Base
-  acts_as_taggable_array_on :tags
+  taggable_array :tags
 end
 @user = User.new(:name => "Bobby")
 ```
@@ -96,7 +95,7 @@ Set, add and remove
 
 ```ruby
 class User < ActiveRecord::Base
-  acts_as_taggable_array_on :tags
+  taggable_array :tags
   scope :by_join_date, ->{order("created_at DESC")}
 end
 

--- a/lib/acts-as-taggable-array-on/version.rb
+++ b/lib/acts-as-taggable-array-on/version.rb
@@ -1,3 +1,3 @@
 module ActsAsTagPgarray
-  VERSION = "0.5.1"
+  VERSION = "0.6.0"
 end


### PR DESCRIPTION
Preperation for next release.
- Bump to 0.6 version
- Default to `taggable_array` alias in README
- Adding a missing change to CHANGELOG
- Small tweaks to readme