### PR TITLE
Fix for single table inheritance models

### DIFF
--- a/lib/acts-as-taggable-array-on/taggable.rb
+++ b/lib/acts-as-taggable-array-on/taggable.rb
@@ -23,14 +23,14 @@ module ActsAsTaggableArrayOn
             subquery_scope = unscoped.select("unnest(#{table_name}.#{tag_name}) as tag").distinct
             subquery_scope = subquery_scope.instance_eval(&block) if block
 
-            from(subquery_scope).pluck("tag")
+            unscoped(:where).from(subquery_scope).pluck("tag")
           end
 
           define_method :"#{tag_name}_cloud" do |options = {}, &block|
             subquery_scope = unscoped.select("unnest(#{table_name}.#{tag_name}) as tag")
             subquery_scope = subquery_scope.instance_eval(&block) if block
 
-            from(subquery_scope).group("tag").order("tag").pluck(Arel.sql("tag, count(*) as count"))
+            unscoped(:where).from(subquery_scope).group("tag").order("tag").pluck(Arel.sql("tag, count(*) as count"))
           end
         end
       end

--- a/lib/acts-as-taggable-array-on/taggable.rb
+++ b/lib/acts-as-taggable-array-on/taggable.rb
@@ -22,15 +22,15 @@ module ActsAsTaggableArrayOn
           define_method :"all_#{tag_name}" do |options = {}, &block|
             subquery_scope = unscoped.select("unnest(#{table_name}.#{tag_name}) as tag").distinct
             subquery_scope = subquery_scope.instance_eval(&block) if block
-
-            unscoped(:where).from(subquery_scope).pluck("tag")
+            # Remove the STI inheritance type from the outer query since it is in the subquery
+            unscope(where: :type).from(subquery_scope).pluck(:tag)
           end
 
           define_method :"#{tag_name}_cloud" do |options = {}, &block|
             subquery_scope = unscoped.select("unnest(#{table_name}.#{tag_name}) as tag")
             subquery_scope = subquery_scope.instance_eval(&block) if block
-
-            unscoped(:where).from(subquery_scope).group("tag").order("tag").pluck(Arel.sql("tag, count(*) as count"))
+            # Remove the STI inheritance type from the outer query since it is in the subquery
+            unscope(where: :type).from(subquery_scope).group(:tag).order(:tag).count(:tag)
           end
         end
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,6 +12,7 @@ require "acts-as-taggable-array-on"
 ActiveRecord::Migration.verbose = false
 
 class User < ActiveRecord::Base; end
+class Admin < User; end
 
 RSpec.configure do |config|
   config.before(:all) do
@@ -37,6 +38,7 @@ def create_database
   ActiveRecord::Schema.define(version: 1) do
     create_table :users do |t|
       t.string :name
+      t.string :type
       t.string :colors, array: true, default: []
       t.text :sizes, array: true, default: []
       t.integer :codes, array: true, default: []


### PR DESCRIPTION
If you have a single table inheritance, e.g

class Post < Article
end

and article has
taggable_array :tags

Calling Post.all_tags will result in an error because the where clause filtering by the submodel type gets repeated outside the subquery

This fix ensures that our query is unscoped outside the subquery

