### PR TITLE
Add support for citext arrays

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,5 +40,9 @@ jobs:
       - name: Create a database
         run: rake db:create
 
+      - name: Install citext extension
+        run: |
+          psql -U postgres -d "acts-as-taggable-array-on_test" -c "CREATE EXTENSION IF NOT EXISTS citext;"
+
       - name: Running a test
         run: bundle exec rspec

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Ruby 2.4 support dropped
 - Support for Ruby 3.0 added
 - Support for Rails 6.1 added
+- Support for citext arrays added
 
 ## 0.6
 - Drop support for `EOL` versions of Ruby (below `2.4)`, and Rails (below `5.2`)

--- a/lib/acts-as-taggable-array-on/taggable.rb
+++ b/lib/acts-as-taggable-array-on/taggable.rb
@@ -6,7 +6,7 @@ module ActsAsTaggableArrayOn
       base.extend(ClassMethod)
     end
 
-    TYPE_MATCHER = {string: "varchar", text: "text", integer: "integer"}
+    TYPE_MATCHER = {string: "varchar", text: "text", integer: "integer", citext: "citext"}
 
     module ClassMethod
       def acts_as_taggable_array_on(tag_name, *)

--- a/spec/acts_as_tag_pgarray/taggable_spec.rb
+++ b/spec/acts_as_tag_pgarray/taggable_spec.rb
@@ -2,14 +2,15 @@ require "spec_helper"
 
 describe ActsAsTaggableArrayOn::Taggable do
   before do
-    @user1 = User.create name: "Tom", colors: ["red", "blue"], sizes: ["medium", "large"], codes: [456, 789]
-    @user2 = User.create name: "Ken", colors: ["black", "white", "red"], sizes: ["small", "large"], codes: [123, 789]
-    @user3 = User.create name: "Joe", colors: ["black", "blue"], sizes: ["small", "medium", "large"], codes: [123, 456, 789]
-    @admin1 = Admin.create name: "Dick", colors: ["purple", "orange"], sizes: ["medium", "large"], codes: [123, 456, 789]
-    @admin2 = Admin.create name: "Harry", colors: ["white", "blue"], sizes: ["small", "large"], codes: [456, 123]
+    @user1 = User.create name: "Tom", colors: ["red", "blue"], sizes: ["medium", "large"], codes: [456, 789], roles: ["user"]
+    @user2 = User.create name: "Ken", colors: ["black", "white", "red"], sizes: ["small", "large"], codes: [123, 789], roles: ["User"]
+    @user3 = User.create name: "Joe", colors: ["black", "blue"], sizes: ["small", "medium", "large"], codes: [123, 456, 789], roles: ["login"]
+    @admin1 = Admin.create name: "Dick", colors: ["purple", "orange"], sizes: ["medium", "large"], codes: [123, 456, 789], roles: ["USER", "Admin"]
+    @admin2 = Admin.create name: "Harry", colors: ["white", "blue"], sizes: ["small", "large"], codes: [456, 123], roles: ["Admin"]
 
     User.acts_as_taggable_array_on :colors
     User.acts_as_taggable_array_on :sizes
+    User.acts_as_taggable_array_on :roles
     User.taggable_array :codes
 
   end
@@ -70,6 +71,13 @@ describe ActsAsTaggableArrayOn::Taggable do
     expect(User.with_all_sizes(["small", "large"])).to match_array([@user2, @user3, @admin2])
     expect(User.without_any_sizes("medium")).to match_array([@user2, @admin2])
     expect(User.without_all_sizes("medium")).to match_array([@user2, @admin2])
+  end
+
+  it "should work with ::citext typed array" do
+    expect(User.with_any_roles(["admin"])).to match_array([@admin1, @admin2])
+    expect(User.with_all_roles(["User", "Admin"])).to match_array([@admin1])
+    expect(User.without_any_roles("USER")).to match_array([@user3, @admin2])
+    expect(User.without_all_roles("UseR")).to match_array([@user3, @admin2])
   end
 
   it "should work with ::integer typed array" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -36,8 +36,6 @@ end
 
 def create_database
   ActiveRecord::Schema.define(version: 1) do
-    enable_extension("citext")
-
     create_table :users do |t|
       t.string :name
       t.string :type

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -36,6 +36,8 @@ end
 
 def create_database
   ActiveRecord::Schema.define(version: 1) do
+    enable_extension("citext") unless extensions.include?("citext")
+
     create_table :users do |t|
       t.string :name
       t.string :type

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -36,12 +36,15 @@ end
 
 def create_database
   ActiveRecord::Schema.define(version: 1) do
+    enable_extension("citext")
+
     create_table :users do |t|
       t.string :name
       t.string :type
       t.string :colors, array: true, default: []
       t.text :sizes, array: true, default: []
       t.integer :codes, array: true, default: []
+      t.citext :roles, array: true, default: []
       t.timestamps null: true
     end
   end


### PR DESCRIPTION
Currently if the tags column is of `citext` type, the generated SQL is invalid. Adding this extra configuration fixes the issue.