### PR TITLE
Relational class method additions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,5 +2,3 @@ source "https://rubygems.org"
 
 # Specify your gem's dependencies in acts-as-pgarray-taggable-on.gemspec
 gemspec
-
-gem "pry"

--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,5 @@ source "https://rubygems.org"
 
 # Specify your gem's dependencies in acts-as-pgarray-taggable-on.gemspec
 gemspec
+
+gem 'pry'

--- a/Gemfile
+++ b/Gemfile
@@ -3,4 +3,4 @@ source "https://rubygems.org"
 # Specify your gem's dependencies in acts-as-pgarray-taggable-on.gemspec
 gemspec
 
-gem 'pry'
+gem "pry"

--- a/README.md
+++ b/README.md
@@ -19,13 +19,14 @@ bundle
 
 
 ## Setup
-To use it, you need to have an array column to act as taggable - `tags`. 
+To use it, you need to have an array column to act as taggable - `tags`.
 
 ```ruby
 class CreateUser < ActiveRecord::Migration
   def change
     create_table :users do |t|
       t.string :tags, array: true, default: []
+      t.boolean :active, default: false
       t.timestamps
     end
     add_index :users, :tags, using: "gin"
@@ -141,6 +142,9 @@ Or simply use your existing scopes:
 ```ruby
 # scope :by_join_date, ->{order("created_at DESC")}
 User.all_tags.by_join_date
+
+# scope :active, -> { where(active: true) }
+User.active.all_tags
 ```
 
 SQL field is named "tag" and you can use it to modify the query.
@@ -162,6 +166,13 @@ You can use block to add scopes to the query.
 
 ```ruby
 User.tags_cloud { where(name: ["ken", "tom"]) }
+```
+
+Or use your existing scopes:
+
+```ruby
+# scope :active, -> { where(active: true) }
+User.active.tags_cloud
 ```
 
 SQL fields are named "tag" and "count" and you can use them to modify the query.

--- a/acts-as-taggable-array-on.gemspec
+++ b/acts-as-taggable-array-on.gemspec
@@ -14,6 +14,7 @@ Gem::Specification.new do |spec|
 
   spec.files = `git ls-files -z`.split("\x0")
   spec.executables = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
+  spec.test_files = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "activerecord", [">= 5.2"]

--- a/acts-as-taggable-array-on.gemspec
+++ b/acts-as-taggable-array-on.gemspec
@@ -14,7 +14,6 @@ Gem::Specification.new do |spec|
 
   spec.files = `git ls-files -z`.split("\x0")
   spec.executables = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
-  spec.test_files = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "activerecord", [">= 5.2"]

--- a/lib/acts-as-taggable-array-on/taggable.rb
+++ b/lib/acts-as-taggable-array-on/taggable.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
-require 'pry'
+
+require "pry"
 
 module ActsAsTaggableArrayOn
   module Taggable
@@ -22,7 +23,7 @@ module ActsAsTaggableArrayOn
         self.class.class_eval do
           define_method :"all_#{tag_name}" do |options = {}, &block|
             # Handles the unique case of prepending method with "where("tag like ?", "aws%")"
-            missing_like_tag_prepend = current_scope&.where_clause&.send(:predicates)&.none? { |pred| pred.to_s.include?('tag like') }
+            missing_like_tag_prepend = current_scope&.where_clause&.send(:predicates)&.none? { |pred| pred.to_s.include?("tag like") }
             if current_scope && missing_like_tag_prepend
               # For relations
               current_scope.pluck(tag_name).flatten.uniq
@@ -37,7 +38,7 @@ module ActsAsTaggableArrayOn
 
           define_method :"#{tag_name}_cloud" do |options = {}, &block|
             # Handles the unique case of prepending method with "where("tag like ?", "aws%")"
-            missing_like_tag_prepend = current_scope&.where_clause&.send(:predicates)&.none? { |pred| pred.to_s.include?('tag like') }
+            missing_like_tag_prepend = current_scope&.where_clause&.send(:predicates)&.none? { |pred| pred.to_s.include?("tag like") }
             if current_scope && missing_like_tag_prepend
               # For relations
               current_scope.pluck(tag_name).flatten.group_by(&:itself).transform_values(&:count)

--- a/lib/acts-as-taggable-array-on/taggable.rb
+++ b/lib/acts-as-taggable-array-on/taggable.rb
@@ -22,10 +22,12 @@ module ActsAsTaggableArrayOn
         self.class.class_eval do
           define_method :"all_#{tag_name}" do |options = {}, &block|
             # Handles the unique case of prepending method with "where("tag like ?", "aws%")"
-            special_prepend_condition = current_scope&.where_clause&.send(:predicates)&.any? { |pred| pred.to_s.include?('tag') }
-            if current_scope && !special_prepend_condition
+            missing_like_tag_prepend = current_scope&.where_clause&.send(:predicates)&.none? { |pred| pred.to_s.include?('tag like') }
+            if current_scope && missing_like_tag_prepend
+              # For relations
               current_scope.pluck(tag_name).flatten.uniq
             else
+              # For classes
               subquery_scope = unscoped.select("unnest(#{table_name}.#{tag_name}) as tag").distinct
               subquery_scope = subquery_scope.instance_eval(&block) if block
               # Remove the STI inheritance type from the outer query since it is in the subquery
@@ -34,10 +36,18 @@ module ActsAsTaggableArrayOn
           end
 
           define_method :"#{tag_name}_cloud" do |options = {}, &block|
-            subquery_scope = unscoped.select("unnest(#{table_name}.#{tag_name}) as tag")
-            subquery_scope = subquery_scope.instance_eval(&block) if block
-            # Remove the STI inheritance type from the outer query since it is in the subquery
-            unscope(where: :type).from(subquery_scope).group(:tag).order(:tag).count(:tag)
+            # Handles the unique case of prepending method with "where("tag like ?", "aws%")"
+            missing_like_tag_prepend = current_scope&.where_clause&.send(:predicates)&.none? { |pred| pred.to_s.include?('tag like') }
+            if current_scope && missing_like_tag_prepend
+              # For relations
+              current_scope.pluck(tag_name).flatten.group_by(&:itself).transform_values(&:count)
+            else
+              # For classes
+              subquery_scope = unscoped.select("unnest(#{table_name}.#{tag_name}) as tag")
+              subquery_scope = subquery_scope.instance_eval(&block) if block
+              # Remove the STI inheritance type from the outer query since it is in the subquery
+              unscope(where: :type).from(subquery_scope).group(:tag).order(:tag).count(:tag)
+            end
           end
         end
       end

--- a/lib/acts-as-taggable-array-on/taggable.rb
+++ b/lib/acts-as-taggable-array-on/taggable.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "pry"
-
 module ActsAsTaggableArrayOn
   module Taggable
     def self.included(base)

--- a/spec/acts_as_tag_pgarray/taggable_spec.rb
+++ b/spec/acts_as_tag_pgarray/taggable_spec.rb
@@ -1,5 +1,6 @@
-
 require "spec_helper"
+
+class Dummy < ActiveRecord::Base; end
 
 describe ActsAsTaggableArrayOn::Taggable do
   before do
@@ -17,12 +18,10 @@ describe ActsAsTaggableArrayOn::Taggable do
 
     User.scope :active, -> { where(active: true) }
     User.scope :inactive, -> { where(active: false) }
-
   end
 
   context "without database table" do
     it "doesn't fail on class method call" do
-      class Dummy < ActiveRecord::Base; end
       Dummy.acts_as_taggable_array_on :tags
     end
   end

--- a/spec/acts_as_tag_pgarray/taggable_spec.rb
+++ b/spec/acts_as_tag_pgarray/taggable_spec.rb
@@ -16,6 +16,7 @@ describe ActsAsTaggableArrayOn::Taggable do
     User.taggable_array :codes
 
     User.scope :active, -> { where(active: true) }
+    User.scope :inactive, -> { where(active: false) }
 
   end
 
@@ -145,6 +146,11 @@ describe ActsAsTaggableArrayOn::Taggable do
     it "returns filtered tags for tag_name with prepended scope and bock" do
       expect(User.where("tag like ?", "bl%").all_colors { where(name: ["Ken", "Joe"]) }).to match_array([@user2, @user3].map(&:colors).flatten.uniq.select { |name| name.start_with? "bl" })
     end
+
+    it "returns filtered tags for tag_name from a scoped relation" do
+      expect(User.active.all_colors).to match_array([@user1, @user2, @admin1].map(&:colors).flatten.uniq)
+      expect(User.inactive.all_colors).to match_array([@user3, @admin2].map(&:colors).flatten.uniq)
+    end
   end
 
   describe "#colors_cloud" do
@@ -169,6 +175,15 @@ describe ActsAsTaggableArrayOn::Taggable do
     it "returns filtered tag cloud for tag_name with prepended scope and block" do
       expect(User.where("tag like ?", "bl%").colors_cloud { where(name: ["Ken", "Joe"]) }).to match_array(
         [@user2, @user3].map(&:colors).flatten.group_by(&:to_s).map { |k, v| [k, v.count] }.select { |name, count| name.start_with? "bl" }
+      )
+    end
+
+    it "returns filtered tag cloud for tag_name from a scoped relation" do
+      expect(User.active.colors_cloud).to match_array(
+        [@user1, @user2, @admin1].map(&:colors).flatten.group_by(&:to_s).map { |k, v| [k, v.count] }
+      )
+      expect(User.inactive.colors_cloud).to match_array(
+        [@user3, @admin2].map(&:colors).flatten.group_by(&:to_s).map { |k, v| [k, v.count] }
       )
     end
   end

--- a/spec/acts_as_tag_pgarray/taggable_spec.rb
+++ b/spec/acts_as_tag_pgarray/taggable_spec.rb
@@ -3,10 +3,10 @@ require "spec_helper"
 
 describe ActsAsTaggableArrayOn::Taggable do
   before do
-    @user1 = User.create name: "Tom", colors: ["red", "blue"], sizes: ["medium", "large"], codes: [456, 789], roles: ["user"], references: ["308f35c6-f819-4faa-9bba-2457de1dde25"]
-    @user2 = User.create name: "Ken", colors: ["black", "white", "red"], sizes: ["small", "large"], codes: [123, 789], roles: ["User"], references: ["e32434a0-39c2-44cc-9c1e-f4c7eebaafb3"]
+    @user1 = User.create name: "Tom", colors: ["red", "blue"], sizes: ["medium", "large"], codes: [456, 789], roles: ["user"], references: ["308f35c6-f819-4faa-9bba-2457de1dde25"], active: true
+    @user2 = User.create name: "Ken", colors: ["black", "white", "red"], sizes: ["small", "large"], codes: [123, 789], roles: ["User"], references: ["e32434a0-39c2-44cc-9c1e-f4c7eebaafb3"], active: true
     @user3 = User.create name: "Joe", colors: ["black", "blue"], sizes: ["small", "medium", "large"], codes: [123, 456, 789], roles: ["login"], references: ["41d9033b-80e1-4784-90f6-0c9eb7537cac"]
-    @admin1 = Admin.create name: "Dick", colors: ["purple", "orange"], sizes: ["medium", "large"], codes: [123, 456, 789], roles: ["USER", "Admin"], references: ["308f35c6-f819-4faa-9bba-2457de1dde25", "e32434a0-39c2-44cc-9c1e-f4c7eebaafb3"]
+    @admin1 = Admin.create name: "Dick", colors: ["purple", "orange"], sizes: ["medium", "large"], codes: [123, 456, 789], roles: ["USER", "Admin"], references: ["308f35c6-f819-4faa-9bba-2457de1dde25", "e32434a0-39c2-44cc-9c1e-f4c7eebaafb3"], active: true
     @admin2 = Admin.create name: "Harry", colors: ["white", "blue"], sizes: ["small", "large"], codes: [456, 123], roles: ["Admin"], references: ["41d9033b-80e1-4784-90f6-0c9eb7537cac"]
 
     User.acts_as_taggable_array_on :colors
@@ -14,6 +14,8 @@ describe ActsAsTaggableArrayOn::Taggable do
     User.acts_as_taggable_array_on :roles
     User.acts_as_taggable_array_on :references
     User.taggable_array :codes
+
+    User.scope :active, -> { where(active: true) }
 
   end
 

--- a/spec/acts_as_tag_pgarray/taggable_spec.rb
+++ b/spec/acts_as_tag_pgarray/taggable_spec.rb
@@ -1,3 +1,4 @@
+
 require "spec_helper"
 
 describe ActsAsTaggableArrayOn::Taggable do
@@ -126,8 +127,6 @@ describe ActsAsTaggableArrayOn::Taggable do
   describe "#all_colors" do
     it "returns all of tag_name" do
       expect(User.all_colors).to match_array([@user1, @user2, @user3, @admin1, @admin2].map(&:colors).flatten.uniq)
-      expect(User.where("tag like ?", "bl%").all_colors).to match_array([@user1, @user2, @user3].map(&:colors).flatten.uniq.select { |name| name.start_with? "bl" })
-      expect(User.where(name: ["Ken", "Tom"]).all_colors).to match_array([@user1, @user2].map(&:colors).flatten.uniq)
       expect(Admin.all_colors).to match_array([@admin1, @admin2].map(&:colors).flatten.uniq)
     end
 
@@ -139,10 +138,6 @@ describe ActsAsTaggableArrayOn::Taggable do
     it "returns filtered tags for tag_name with prepended scope" do
       expect(User.where("tag like ?", "bl%").all_colors).to match_array([@user1, @user2, @user3].map(&:colors).flatten.uniq.select { |name| name.start_with? "bl" })
       expect(Admin.where("tag like ?", "bl%").all_colors).to match_array([@admin2].map(&:colors).flatten.uniq.select { |name| name.start_with? "bl" })
-    end
-
-    it "returns filtered tags for tag_name from an AR relation" do
-      expect(User.where(name: ["Tom", "Ken"]).all_colors).to match_array([@user1, @user2].map(&:colors).flatten.uniq)
     end
 
     it "returns filtered tags for tag_name with prepended scope and bock" do

--- a/spec/acts_as_tag_pgarray/taggable_spec.rb
+++ b/spec/acts_as_tag_pgarray/taggable_spec.rb
@@ -126,6 +126,8 @@ describe ActsAsTaggableArrayOn::Taggable do
   describe "#all_colors" do
     it "returns all of tag_name" do
       expect(User.all_colors).to match_array([@user1, @user2, @user3, @admin1, @admin2].map(&:colors).flatten.uniq)
+      expect(User.where("tag like ?", "bl%").all_colors).to match_array([@user1, @user2, @user3].map(&:colors).flatten.uniq.select { |name| name.start_with? "bl" })
+      expect(User.where(name: ["Ken", "Tom"]).all_colors).to match_array([@user1, @user2].map(&:colors).flatten.uniq)
       expect(Admin.all_colors).to match_array([@admin1, @admin2].map(&:colors).flatten.uniq)
     end
 
@@ -137,6 +139,10 @@ describe ActsAsTaggableArrayOn::Taggable do
     it "returns filtered tags for tag_name with prepended scope" do
       expect(User.where("tag like ?", "bl%").all_colors).to match_array([@user1, @user2, @user3].map(&:colors).flatten.uniq.select { |name| name.start_with? "bl" })
       expect(Admin.where("tag like ?", "bl%").all_colors).to match_array([@admin2].map(&:colors).flatten.uniq.select { |name| name.start_with? "bl" })
+    end
+
+    it "returns filtered tags for tag_name from an AR relation" do
+      expect(User.where(name: ["Tom", "Ken"]).all_colors).to match_array([@user1, @user2].map(&:colors).flatten.uniq)
     end
 
     it "returns filtered tags for tag_name with prepended scope and bock" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,7 +2,7 @@ $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), "..", "lib"))
 $LOAD_PATH.unshift(File.dirname(__FILE__))
 require "rspec"
 require "active_record/railtie"
-ActiveRecord::Base.logger = Logger.new(STDERR)
+ActiveRecord::Base.logger = Logger.new($stderr)
 ActiveRecord::Base.logger.level = 3
 
 require "acts-as-taggable-array-on"
@@ -12,6 +12,7 @@ require "acts-as-taggable-array-on"
 ActiveRecord::Migration.verbose = false
 
 class User < ActiveRecord::Base; end
+
 class Admin < User; end
 
 RSpec.configure do |config|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -47,6 +47,7 @@ def create_database
       t.integer :codes, array: true, default: []
       t.citext :roles, array: true, default: []
       t.uuid :references, array: true, default: []
+      t.boolean :active, default: false
       t.timestamps null: true
     end
   end


### PR DESCRIPTION
This PR adds additional functionality allowing the following class methods the ability to handle scoped relations calling the class method, it handles the specific exception for the "tag like" prepend, and adds testing for the scoped relation logic
- "all_#{tag_name}"
- "#{tag_name}_cloud"
 